### PR TITLE
Call Find/Destroy with integer id, instead of datastore.Key.

### DIFF
--- a/app/server/dstore.go
+++ b/app/server/dstore.go
@@ -48,9 +48,9 @@ func (d *DStore) checkKey(key *datastore.Key) {
 	}
 }
 
-//func (d *DStore) IDKey(id int64) *datastore.Key {
-//return datastore.IDKey(d.kind, id, nil)
-//}
+func (d *DStore) IDKey(id int64) *datastore.Key {
+	return datastore.IDKey(d.kind, id, nil)
+}
 
 func (d *DStore) Get(key *datastore.Key, container interface{}) error {
 	d.checkKey(key)

--- a/app/server/simple_model.go
+++ b/app/server/simple_model.go
@@ -14,6 +14,7 @@ type Repo interface {
 	Delete(*datastore.Key) error
 	NewQuery() *datastore.Query
 	GetAll(*datastore.Query, interface{}) ([]*datastore.Key, error)
+	IDKey(int64) *datastore.Key
 }
 
 func (s *Simple) SetKind(r Repo) {
@@ -21,21 +22,36 @@ func (s *Simple) SetKind(r Repo) {
 
 }
 
-func (s *Simple) Save(r Repo) (*datastore.Key, error) {
+func (s *Simple) IDKey(r Repo, id int) *datastore.Key {
+	s.SetKind(r)
+
+	return r.IDKey(int64(id))
+}
+
+func (s *Simple) Save(r Repo) (int, error) {
 	s.SetKind(r)
 
 	key, err := r.Create(s)
-	return key, err
+
+	if err != nil {
+		return 0, err
+
+	}
+
+	return int(key.ID), nil
 }
 
-func (s *Simple) Find(r Repo, k *datastore.Key) error {
+func (s *Simple) Find(r Repo, id int) error {
 	s.SetKind(r)
+
+	k := s.IDKey(r, id)
 
 	return r.Get(k, s)
 }
 
-func (s *Simple) Destroy(r Repo, k *datastore.Key) error {
+func (s *Simple) Destroy(r Repo, id int) error {
 	s.SetKind(r)
+	k := s.IDKey(r, id)
 
 	return r.Delete(k)
 }

--- a/app/server/simple_model_test.go
+++ b/app/server/simple_model_test.go
@@ -16,7 +16,7 @@ func TestSimpleModelSaveFindDestroy(t *testing.T) {
 	s.SetKind(d)
 	defer RefreshDStore(d)
 
-	key, err := s.Save(d)
+	id, err := s.Save(d)
 
 	if err != nil {
 		t.Errorf("Failed to save: %v.", err)
@@ -24,17 +24,17 @@ func TestSimpleModelSaveFindDestroy(t *testing.T) {
 
 	ss := Simple{}
 
-	ss.Find(d, key)
+	ss.Find(d, id)
 
 	if !reflect.DeepEqual(s, ss) {
 		t.Errorf("Expected %v, got %v.", s, ss)
 	}
 
-	(&Simple{}).Destroy(d, key)
+	(&Simple{}).Destroy(d, id)
 
 	ss = Simple{}
 
-	if err := ss.Find(d, key); err == nil {
+	if err := ss.Find(d, id); err == nil {
 		t.Errorf("Expecred error, nothing raised.")
 	} else if !reflect.DeepEqual(ss, Simple{}) {
 		t.Errorf("Expected empty struct, got %v.", ss)


### PR DESCRIPTION
I think using `id` for Find and Delete is more straightforward rather than using `datastore.Key` since it's going to be specified in the request params.